### PR TITLE
Avoid the warning about non-libraries being installed to "lib" 

### DIFF
--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -43,6 +43,8 @@ class Rdkit < Formula
     ENV.j1
     system "make"
     system "make install"
+    # Remove the ghost .cmake files which will cause a warning if we install them to /lib/
+    rm_f Dir["#{lib}/*.cmake"]
   end
 
   def caveats


### PR DESCRIPTION
Previously the installation would give the following warning::

```
Warning: Non-libraries were installed to "lib".
Installing non-libraries to "lib" is bad practice.
The offending files are:
/usr/local/Cellar/rdkit/2011.12.1/lib/rdkit-config-version.cmake
/usr/local/Cellar/rdkit/2011.12.1/lib/rdkit-config.cmake
/usr/local/Cellar/rdkit/2011.12.1/lib/rdkit-targets-none.cmake
/usr/local/Cellar/rdkit/2011.12.1/lib/rdkit-targets.cmake
```

This fix removes *.cmake files from "lib".
