### PR TITLE
Update for v2016.03.1

### DIFF
--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -1,14 +1,9 @@
 require 'formula'
 
 class Rdkit < Formula
-  homepage 'http://rdkit.org/'
-  url 'https://github.com/rdkit/rdkit/archive/Release_2015_09_2.tar.gz'
-  sha1 'f81b8519051b1d3f6e7379e49e5f826f580710fb'
-
-  # devel do
-  #   url 'https://github.com/rdkit/rdkit/archive/Release_2014_03_1beta1.tar.gz'
-  #   version '2014.03.1b1'
-  # end
+  homepage "http://rdkit.org/"
+  url "https://github.com/rdkit/rdkit/archive/Release_2016_03_1.tar.gz"
+  sha256 "c0ab786ba745bb355141875e6b7fcc94a55cb8709fdc3508e38575b228f668f1"
 
   head do
     url 'https://github.com/rdkit/rdkit.git'

--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -16,7 +16,6 @@ class Rdkit < Formula
   option "with-pycairo", "Build with py2cairo/py3cairo support"
 
   depends_on 'cmake' => :build
-  depends_on 'wget' => :build
   depends_on 'swig' => :build if build.with? 'java'
   depends_on 'boost'
   depends_on :python3 => :optional
@@ -35,7 +34,6 @@ class Rdkit < Formula
 
   def install
     args = std_cmake_parameters.split
-    args << '-DRDK_INSTALL_INTREE=OFF'
 
     # build java wrapper?
     if build.with? 'java'
@@ -53,20 +51,9 @@ class Rdkit < Formula
       args << '-DRDK_BUILD_SWIG_WRAPPERS=ON'
     end
 
-    # build inchi support?
-    if build.with? 'inchi'
-      system "cd External/INCHI-API; bash download-inchi.sh"
-      args << '-DRDK_BUILD_INCHI_SUPPORT=ON'
-    end
-
-    # build avalon tools?
-    if build.with? 'avalon'
-      system "curl -L https://downloads.sourceforge.net/project/avalontoolkit/AvalonToolkit_1.2/AvalonToolkit_1.2.0.source.tar -o External/AvalonTools/avalon.tar"
-      system "tar xf External/AvalonTools/avalon.tar -C External/AvalonTools"
-      args << '-DRDK_BUILD_AVALON_SUPPORT=ON'
-      args << "-DAVALONTOOLS_DIR=#{buildpath}/External/AvalonTools/SourceDistribution"
-    end
-
+    args << "-DRDK_INSTALL_INTREE=OFF"
+    args << "-DRDK_BUILD_AVALON_SUPPORT=ON" if build.with? "avalon"
+    args << "-DRDK_BUILD_INCHI_SUPPORT=ON" if build.with? "inchi"
     args << '-DRDK_BUILD_CPP_TESTS=OFF'
     args << '-DRDK_INSTALL_STATIC_LIBS=OFF' unless build.with? 'postgresql'
 

--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -53,6 +53,7 @@ class Rdkit < Formula
 
     args << "-DRDK_INSTALL_INTREE=OFF"
     args << "-DRDK_BUILD_AVALON_SUPPORT=ON" if build.with? "avalon"
+    args << "-DRDK_BUILD_PGSQL=ON" if build.with? "postgresql"
     args << "-DRDK_BUILD_INCHI_SUPPORT=ON" if build.with? "inchi"
     args << '-DRDK_BUILD_CPP_TESTS=OFF'
     args << '-DRDK_INSTALL_STATIC_LIBS=OFF' unless build.with? 'postgresql'
@@ -80,15 +81,16 @@ class Rdkit < Formula
     system "cmake", *args
     system "make"
     system "make install"
+
     # Remove the ghost .cmake files which will cause a warning if we install them to 'lib'
     rm_f Dir["#{lib}/*.cmake"]
-    if build.with? 'postgresql'
-      ENV['RDBASE'] = "#{prefix}"
-      ENV.append 'CFLAGS', "-I#{include}/rdkit"
-      cd 'Code/PgSQL/rdkit' do
-        system "make"
-        system "make install"
-      end
+
+    # Install postgresql files
+    if build.with? "postgresql"
+      mv "Code/PgSQL/rdkit/rdkit.sql91.in", "Code/PgSQL/rdkit/rdkit--3.4.sql"
+      (share + 'postgresql/extension').install "Code/PgSQL/rdkit/rdkit--3.4.sql"
+      (share + 'postgresql/extension').install "Code/PgSQL/rdkit/rdkit.control"
+      (lib + 'postgresql').install "Code/PgSQL/rdkit/rdkit.so"
     end
   end
 


### PR DESCRIPTION
There's a bit more going on here than usual:

- InChI and Avalon options now just rely on cmake to download the needed libraries
- Switched to cmake option for postgres cartridge. However, the generated `pgsql_install.sh` script isn't used directly, instead we use homebrew's `.install` method so files are installed to rdkit's isolated directory in the Cellar and then homebrew handles symlinking into the actual directories.
- Java bindings now appear to build correctly. I have never used these so it may be worth checking this is all alright. In particular the note at the end I added about the jnilib file - is this actually needed and is it common practice to install it in `/Library/Java/Extensions/`?