### PR TITLE
add TravisCI to check most update-to-date build for homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+os: osx
+dist: trusty
+language: generic
+
+sudo: false
+
+before_install:
+ - brew update
+ - brew install python3
+ - pip install numpy
+ - pip3 install numpy
+
+install:
+ - travis_wait 30 brew install ./Formula/rdkit.rb --HEAD --build-from-source --with-python3 --without-numpy


### PR DESCRIPTION
This can help us to find if there is a problem to build rdkit through homebrew more easily.
Current branch is at https://travis-ci.org/hsiaoyi0504/homebrew-rdkit/builds/303879181.
However, still need administrator to setup the TravisCI for this repo.