### PR TITLE
Prevent new homebrew warnings

### DIFF
--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -16,12 +16,12 @@ class Rdkit < Formula
   option "with-pycairo", "Build with py2cairo/py3cairo support"
   option "without-numpy", "Use your own numpy instead of Homebrew's numpy"
 
-  depends_on 'cmake' => :build
-  depends_on 'swig' => :build if build.with? 'java'
-  depends_on 'boost'
+  depends_on "cmake" => :build
+  depends_on "swig" => :build if build.with? 'java'
+  depends_on "boost"
   depends_on "eigen" => :recommended
-  depends_on :python3 => :optional
-  depends_on :postgresql => :optional
+  depends_on "python3" => :optional
+  depends_on "postgresql" => :optional
 
   # Different dependencies if building for python3
   if build.with? "python3"
@@ -29,7 +29,7 @@ class Rdkit < Formula
     depends_on "numpy" => [:recommended, "with-python3"]
     depends_on "py3cairo" if build.with? "pycairo"
   else
-    depends_on :python
+    depends_on "python"
     depends_on "boost-python"
     depends_on "numpy" => :recommended
     depends_on "py2cairo" if build.with? "pycairo"


### PR DESCRIPTION
There were some warnings about `depends_on` sections. This commit fixes these warnings.