### PR TITLE
Modify the way to install python3 and boost-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ sudo: false
 
 before_install:
  - brew update
- - brew install python3
- - pip2 install numpy
+ - brew upgrade python
+ # Don't need `pip2 install numpy` because numpy has already been install: see https://docs.travis-ci.com/user/reference/osx/#Python-related-tools
  - pip3 install numpy
 
 matrix:

--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -22,16 +22,15 @@ class Rdkit < Formula
   depends_on "eigen" => :recommended
   depends_on "python3" => :optional
   depends_on "postgresql" => :optional
+  depends_on "numpy" => :recommended
 
   # Different dependencies if building for python3
   if build.with? "python3"
-    depends_on "boost-python" => "with-python3"
-    depends_on "numpy" => [:recommended, "with-python3"]
+    depends_on "boost-python3"
     depends_on "py3cairo" if build.with? "pycairo"
   else
-    depends_on "python"
+    depends_on "python@2" => :recommended if MacOS.version <= :snow_leopard
     depends_on "boost-python"
-    depends_on "numpy" => :recommended
     depends_on "py2cairo" if build.with? "pycairo"
   end
 


### PR DESCRIPTION
Few updates:
- use `boost-python3` in python3-based installation because they are different formulas now.
  - https://github.com/Homebrew/homebrew-core/blob/master/Formula/boost-python.rb
  - https://github.com/Homebrew/homebrew-core/blob/master/Formula/boost-python3.rb
- `numpy` doesn't have `with-python3` option anymore.
   - https://github.com/Homebrew/homebrew-core/blob/master/Formula/numpy.rb
- `python` formula is for `python3` and `python@2` is for `python2`. See #55.