### PR TITLE
Pin boost and boost-python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_install:
  - brew update
  - which python3 || brew install python3
  - pip3 install numpy
- - brew unlink boost || echo 'brew: boost not installed'
- - brew unlink boost-python3 || echo 'brew: boost-python3 not installed'
+ - brew unlink boost || echo boost_not_installed
+ - brew unlink boost-python3 || echo boost-python3_not_installed
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
 
 matrix:
   include:
-    - install: travis_wait 180 brew install ./Formula/boost\@1.70.rb ./Formula/boost-python3\@1.70.rb ./Formula/rdkit.rb --HEAD --build-from-source --with-python3 --without-numpy
+    - install: travis_wait 180 brew install ./Formula/boost\@1.70.rb ./Formula/boost-python3\@1.70.rb ./Formula/rdkit.rb --HEAD --build-from-source --with-python3
       env:
         - version=HEAD HOMEBREW_DEVELOPER=1
-    - install: travis_wait 180 brew install ./Formula/boost\@1.70.rb ./Formula/boost-python3\@1.70.rb ./Formula/rdkit.rb --build-from-source --with-python3 --without-numpy
+    - install: travis_wait 180 brew install ./Formula/boost\@1.70.rb ./Formula/boost-python3\@1.70.rb ./Formula/rdkit.rb --build-from-source --with-python3
       env:
         - version=current HOMEBREW_DEVELOPER=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
 
 matrix:
   include:
-    - install: travis_wait 50 brew install ./Formula/boost\@1.70.rb ./Formula/boost-python3\@1.70.rb ./Formula/rdkit.rb --HEAD --build-from-source --with-python3 --without-numpy
+    - install: travis_wait 180 brew install ./Formula/boost\@1.70.rb ./Formula/boost-python3\@1.70.rb ./Formula/rdkit.rb --HEAD --build-from-source --with-python3 --without-numpy
       env:
         - version=HEAD HOMEBREW_DEVELOPER=1
-    - install: travis_wait 50 brew install ./Formula/boost\@1.70.rb ./Formula/boost-python3\@1.70.rb ./Formula/rdkit.rb --build-from-source --with-python3 --without-numpy
+    - install: travis_wait 180 brew install ./Formula/boost\@1.70.rb ./Formula/boost-python3\@1.70.rb ./Formula/rdkit.rb --build-from-source --with-python3 --without-numpy
       env:
         - version=current HOMEBREW_DEVELOPER=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,9 @@ before_install:
 
 matrix:
   include:
-    - install: travis_wait 50 brew install ./Formula/rdkit.rb --HEAD --build-from-source --with-python3 --without-numpy
+    - install: travis_wait 50 brew install ./Formula/boost\@1.70.rb ./Formula/boost-python3\@1.70.rb ./Formula/rdkit.rb --HEAD --build-from-source --with-python3 --without-numpy
       env:
         - version=HEAD HOMEBREW_DEVELOPER=1
-    - install: travis_wait 50 brew install ./Formula/rdkit.rb --build-from-source --with-python3 --without-numpy
+    - install: travis_wait 50 brew install ./Formula/boost\@1.70.rb ./Formula/boost-python3\@1.70.rb ./Formula/rdkit.rb --build-from-source --with-python3 --without-numpy
       env:
         - version=current HOMEBREW_DEVELOPER=1
-      

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ before_install:
  - brew update
  - which python3 || brew install python3
  - pip3 install numpy
- - brew unlink boost boost-python3
+ - brew unlink boost || echo 'brew: boost not installed'
+ - brew unlink boost-python3 || echo 'brew: boost-python3 not installed'
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
  - brew update
  - which python3 || brew install python3
  - pip3 install numpy
+ - brew unlink boost boost-python3
 
 matrix:
   include:

--- a/Formula/boost-python3@1.70.rb
+++ b/Formula/boost-python3@1.70.rb
@@ -1,0 +1,104 @@
+class BoostPython3AT170 < Formula
+  desc "C++ library for C++/Python3 interoperability"
+  homepage "https://www.boost.org/"
+  url "https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2"
+  sha256 "430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778"
+  revision 1
+  head "https://github.com/boostorg/boost.git"
+
+  bottle do
+    cellar :any
+    sha256 "df5614e51cd271c477ac5a614a196180637c22f9c88b38b05c23e28a46db2c25" => :mojave
+    sha256 "fc247eaaa4e2cbe16f3acf5d88485f795fee38872fdcab2bbb0012340c5e4c30" => :high_sierra
+    sha256 "d1ff523535c6e1fafe64007fbe835c1432ac86ab1e5779b12288f9c4d57506b3" => :sierra
+  end
+
+  depends_on "boost"
+  depends_on "python"
+
+  resource "numpy" do
+    url "https://files.pythonhosted.org/packages/2d/80/1809de155bad674b494248bcfca0e49eb4c5d8bee58f26fe7a0dd45029e2/numpy-1.15.4.zip"
+    sha256 "3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7"
+  end
+
+  def install
+    # "layout" should be synchronized with boost
+    args = ["--prefix=#{prefix}",
+            "--libdir=#{lib}",
+            "-d2",
+            "-j#{ENV.make_jobs}",
+            "--layout=tagged-1.66",
+            # --no-cmake-config should be dropped if possible in next version
+            "--no-cmake-config",
+            "--user-config=user-config.jam",
+            "threading=multi,single",
+            "link=shared,static"]
+
+    # Boost is using "clang++ -x c" to select C compiler which breaks C++14
+    # handling using ENV.cxx14. Using "cxxflags" and "linkflags" still works.
+    args << "cxxflags=-std=c++14"
+    if ENV.compiler == :clang
+      args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+    end
+
+    # disable python detection in bootstrap.sh; it guesses the wrong include
+    # directory for Python 3 headers, so we configure python manually in
+    # user-config.jam below.
+    inreplace "bootstrap.sh", "using python", "#using python"
+
+    pyver = Language::Python.major_minor_version "python3"
+    py_prefix = Formula["python3"].opt_frameworks/"Python.framework/Versions/#{pyver}"
+
+    numpy_site_packages = buildpath/"homebrew-numpy/lib/python#{pyver}/site-packages"
+    numpy_site_packages.mkpath
+    ENV["PYTHONPATH"] = numpy_site_packages
+    resource("numpy").stage do
+      system "python3", *Language::Python.setup_install_args(buildpath/"homebrew-numpy")
+    end
+
+    # Force boost to compile with the desired compiler
+    (buildpath/"user-config.jam").write <<~EOS
+      using darwin : : #{ENV.cxx} ;
+      using python : #{pyver}
+                   : python3
+                   : #{py_prefix}/include/python#{pyver}m
+                   : #{py_prefix}/lib ;
+    EOS
+
+    system "./bootstrap.sh", "--prefix=#{prefix}", "--libdir=#{lib}",
+                             "--with-libraries=python", "--with-python=python3",
+                             "--with-python-root=#{py_prefix}"
+
+    system "./b2", "--build-dir=build-python3", "--stagedir=stage-python3",
+                   "python=#{pyver}", *args
+
+    lib.install Dir["stage-python3/lib/*py*"]
+    doc.install Dir["libs/python/doc/*"]
+  end
+
+  test do
+    (testpath/"hello.cpp").write <<~EOS
+      #include <boost/python.hpp>
+      char const* greet() {
+        return "Hello, world!";
+      }
+      BOOST_PYTHON_MODULE(hello)
+      {
+        boost::python::def("greet", greet);
+      }
+    EOS
+
+    pyincludes = Utils.popen_read("python3-config --includes").chomp.split(" ")
+    pylib = Utils.popen_read("python3-config --ldflags").chomp.split(" ")
+    pyver = Language::Python.major_minor_version("python3").to_s.delete(".")
+
+    system ENV.cxx, "-shared", "hello.cpp", "-L#{lib}", "-lboost_python#{pyver}", "-o",
+           "hello.so", *pyincludes, *pylib
+
+    output = <<~EOS
+      import hello
+      print(hello.greet())
+    EOS
+    assert_match "Hello, world!", pipe_output("python3", output, 0)
+  end
+end

--- a/Formula/boost-python3@1.70.rb
+++ b/Formula/boost-python3@1.70.rb
@@ -13,8 +13,8 @@ class BoostPython3AT170 < Formula
     sha256 "d1ff523535c6e1fafe64007fbe835c1432ac86ab1e5779b12288f9c4d57506b3" => :sierra
   end
 
-  depends_on "boost"
-  depends_on "python"
+  depends_on "boost@1.70"
+  depends_on "python3"
 
   resource "numpy" do
     url "https://files.pythonhosted.org/packages/2d/80/1809de155bad674b494248bcfca0e49eb4c5d8bee58f26fe7a0dd45029e2/numpy-1.15.4.zip"

--- a/Formula/boost@1.70.rb
+++ b/Formula/boost@1.70.rb
@@ -1,0 +1,106 @@
+class BoostAT170 < Formula
+  desc "Collection of portable C++ source libraries"
+  homepage "https://www.boost.org/"
+  url "https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2"
+  sha256 "430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778"
+  head "https://github.com/boostorg/boost.git"
+
+  bottle do
+    cellar :any
+    sha256 "8089ad2fdc0edffcd0222043fda9a99bf82abf30f334305b9068fbef85b44893" => :mojave
+    sha256 "57b8e7c324620079499dfab19f894d7d2929d192f375ed9f09ebbff55c97f9f6" => :high_sierra
+    sha256 "98655462f9bf15f157f07fd27926d5adceb7fa3e966dd1ed5a096b68b8099474" => :sierra
+  end
+
+  depends_on "icu4c"
+
+  def install
+    # Force boost to compile with the desired compiler
+    open("user-config.jam", "a") do |file|
+      file.write "using darwin : : #{ENV.cxx} ;\n"
+    end
+
+    # libdir should be set by --prefix but isn't
+    icu4c_prefix = Formula["icu4c"].opt_prefix
+    bootstrap_args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      --with-icu=#{icu4c_prefix}
+    ]
+
+    # Handle libraries that will not be built.
+    without_libraries = ["python", "mpi"]
+
+    # Boost.Log cannot be built using Apple GCC at the moment. Disabled
+    # on such systems.
+    without_libraries << "log" if ENV.compiler == :gcc
+
+    bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"
+
+    # layout should be synchronized with boost-python and boost-mpi
+    #
+    # --no-cmake-config should be dropped if possible in next version
+    args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      -d2
+      -j#{ENV.make_jobs}
+      --layout=tagged-1.66
+      --user-config=user-config.jam
+      --no-cmake-config
+      -sNO_LZMA=1
+      -sNO_ZSTD=1
+      install
+      threading=multi,single
+      link=shared,static
+    ]
+
+    # Boost is using "clang++ -x c" to select C compiler which breaks C++14
+    # handling using ENV.cxx14. Using "cxxflags" and "linkflags" still works.
+    args << "cxxflags=-std=c++14"
+    if ENV.compiler == :clang
+      args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+    end
+
+    system "./bootstrap.sh", *bootstrap_args
+    system "./b2", "headers"
+    system "./b2", *args
+  end
+
+  def caveats
+    s = ""
+    # ENV.compiler doesn't exist in caveats. Check library availability
+    # instead.
+    if Dir["#{lib}/libboost_log*"].empty?
+      s += <<~EOS
+        Building of Boost.Log is disabled because it requires newer GCC or Clang.
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <boost/algorithm/string.hpp>
+      #include <string>
+      #include <vector>
+      #include <assert.h>
+      using namespace boost::algorithm;
+      using namespace std;
+
+      int main()
+      {
+        string str("a,b");
+        vector<string> strVec;
+        split(strVec, str, is_any_of(","));
+        assert(strVec.size()==2);
+        assert(strVec[0]=="a");
+        assert(strVec[1]=="b");
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-std=c++14", "-stdlib=libc++", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -18,13 +18,13 @@ class Rdkit < Formula
 
   depends_on "cmake" => :build
   depends_on "swig" => :build if build.with? 'java'
-  # depends_on "boost@1.70"
+  depends_on "boost@1.70"
   depends_on "eigen" => :recommended
   depends_on "python3" => :optional
   depends_on "postgresql" => :optional
 
   # Different dependencies if building for python3
-  # depends_on "boost-python3@1.70"
+  depends_on "boost-python3@1.70"
   depends_on "numpy" => [:recommended, "with-python3"]
   depends_on "py3cairo" if build.with? "pycairo"
 

--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -18,13 +18,13 @@ class Rdkit < Formula
 
   depends_on "cmake" => :build
   depends_on "swig" => :build if build.with? 'java'
-  depends_on "boost"
+  # depends_on "boost@1.70"
   depends_on "eigen" => :recommended
   depends_on "python3" => :optional
   depends_on "postgresql" => :optional
 
   # Different dependencies if building for python3
-  depends_on "boost-python3"
+  # depends_on "boost-python3@1.70"
   depends_on "numpy" => [:recommended, "with-python3"]
   depends_on "py3cairo" if build.with? "pycairo"
 


### PR DESCRIPTION
Hello,
This should make the rdkit formula much more stable.
I did not create the two boost-related formulas (at version 1.70).
I just took them from the history of the homebrew-core
repository of formulas.
The only drawback I see is that the build time for rdkit on macs
will significantly increase.
But, as a Unix user, I have to admit that seeing something broken today
that was working yesterday annoys me _a_ _lot_.
So, having the rdkit homebrew formula being more reproducible
is a net advantage.
Regards,
F.
